### PR TITLE
Added exit error to hugo-encrypt

### DIFF
--- a/hugo-encrypt.go
+++ b/hugo-encrypt.go
@@ -97,5 +97,6 @@ func main() {
 	})
 	if err != nil {
 		fmt.Printf("filepath.Walk() returned %v\n", err)
+		panic(err)
 	}
 }


### PR DESCRIPTION
## Changes
Added a panic on main so it returns a different exit code when an error occurs.

## Reason behind the change
When running the code in CI/CD if there is an error but it still returns an exit code of 0 the pipeline can't know.